### PR TITLE
Fix NPE in PreviewFragment

### DIFF
--- a/src/com/android/wallpaper/picker/PreviewFragment.java
+++ b/src/com/android/wallpaper/picker/PreviewFragment.java
@@ -227,12 +227,16 @@ public abstract class PreviewFragment extends Fragment implements
         // Workaround as we don't have access to bottomDialogCornerRadius, mBottomSheet radii are
         // set to dialogCornerRadius by default.
         GradientDrawable bottomSheetBackground = (GradientDrawable) mBottomSheet.getBackground();
-        float[] radii = bottomSheetBackground.getCornerRadii();
-        for (int i = 0; i < radii.length; i++) {
-            radii[i]*=2f;
+        try {
+            float[] radii = bottomSheetBackground.getCornerRadii();
+            for (int i = 0; i < radii.length; i++) {
+                radii[i]*=2f;
+            }
+            bottomSheetBackground = ((GradientDrawable)bottomSheetBackground.mutate());
+            bottomSheetBackground.setCornerRadii(radii);
+        } catch (NullPointerException npe) {
+           // Log.e(TAG, "cornerRadii not available", npe);
         }
-        bottomSheetBackground = ((GradientDrawable)bottomSheetBackground.mutate());
-        bottomSheetBackground.setCornerRadii(radii);
         mBottomSheet.setBackground(bottomSheetBackground);
 
         mBottomSheetInitialState = (savedInstanceState == null) ? STATE_EXPANDED


### PR DESCRIPTION
Catch NPE in GradientDrawable::getCornerRadii existing due to
poor SDK implementation and incorrect documentation.

Fixes #1 